### PR TITLE
feat: shrink image size from 1.6GB to 0.4GB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,3 @@ services:
     restart: unless-stopped
     ports:
       - "3000:3000" # Replace with "127.0.0.1:3000:3000" if you are using a reverse proxy
-    environment:
-      - "NEXT_TELEMETRY_DISABLED=1"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,31 @@
-FROM node:lts-bullseye
+FROM alpine AS clone
 WORKDIR /app
-RUN apt update -y && apt upgrade -y \
-    && apt install -y --no-install-recommends git \
-    && apt autoclean -y \
-    && apt autoremove -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm install -g pnpm \
-    && git clone --depth=1 https://github.com/nesaku/BiblioReads.git . \
+
+RUN apk update \
+    && apk add git \
+    && git clone --depth=1 https://github.com/nesaku/BiblioReads.git .
+
+FROM node:alpine AS build
+WORKDIR /app
+COPY --from=clone /app/ /app/
+
+RUN npm install -g pnpm \
     && pnpm install \
-    && pnpm build
+    && pnpm build \
+    && pnpm prune --production
+
+FROM node:alpine AS deploy
+WORKDIR /app
+
+ENV NEXT_TELEMETRY_DISABLED 1
+RUN npm install -g pnpm
+
+COPY --from=build /app/package.json /app/package.json
+COPY --from=build /app/next.config.js /app/next.config.js
+COPY --from=build /app/public/ /app/public/
+COPY --from=build /app/.next/ /app/.next/
+COPY --from=build /app/node_modules/ /app/node_modules/
+
+USER node
+CMD [ "pnpm", "start" ]
 EXPOSE 3000
-CMD ["pnpm", "start"]


### PR DESCRIPTION
Hey,

I recently noticed that the docker image size is around 1.6GB when installed which is quite heavy, thus I'm sending some improvements here to shrink the size to around 400MB by using Docker build steps and Alpine Linux base images. Let me know if you have any questions.

Cheers